### PR TITLE
Update to 6.5.1, fix header attribute names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "california-state-web-template-react",
       "version": "0.1.0",
       "dependencies": {
-        "@cagovweb/state-template": "^6.5.0",
+        "@cagovweb/state-template": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -1882,9 +1882,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@cagovweb/state-template": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@cagovweb/state-template/-/state-template-6.5.0.tgz",
-      "integrity": "sha512-97kf30N4g7bWPKEs6Lepu7/hdBaHmiMCpMeH7TkjEW2UjvhvOfCKutch9BVbtuRwrK8/WUWbrfB8C6OUtMItHQ=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@cagovweb/state-template/-/state-template-6.5.1.tgz",
+      "integrity": "sha512-tdaef8qIzCWQol8BZ4MNCV1GULWjNrNFUmsTFSYhpT58p2OenmpT4eICjDJMJrBKeAabX6GziQ1eESG8k+B8Ng=="
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
@@ -18538,9 +18538,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@cagovweb/state-template": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@cagovweb/state-template/-/state-template-6.5.0.tgz",
-      "integrity": "sha512-97kf30N4g7bWPKEs6Lepu7/hdBaHmiMCpMeH7TkjEW2UjvhvOfCKutch9BVbtuRwrK8/WUWbrfB8C6OUtMItHQ=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@cagovweb/state-template/-/state-template-6.5.1.tgz",
+      "integrity": "sha512-tdaef8qIzCWQol8BZ4MNCV1GULWjNrNFUmsTFSYhpT58p2OenmpT4eICjDJMJrBKeAabX6GziQ1eESG8k+B8Ng=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://Office-of-Digital-Services.github.io/California-State-Web-Template-react",
   "dependencies": {
-    "@cagovweb/state-template": "^6.5.0",
+    "@cagovweb/state-template": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/structure/SiteHeader/SiteHeader.js
+++ b/src/structure/SiteHeader/SiteHeader.js
@@ -23,7 +23,7 @@ const SiteHeader = ({ stateText, departmentText }) => (
       <div className="header-organization-banner">
         <a href="/">
           <div className="logo-assets">
-            <svg class="logo-img" alt="State Template Logo" style={{ aspectRatio: '1/1' }} version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXLink="http://www.w3.org/1999/xlink" viewBox="0 0 56 56" xmlSpace="preserve">
+            <svg className="logo-img" alt="State Template Logo" style={{ aspectRatio: '1/1' }} version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0 0 56 56" xmlSpace="preserve">
               <g>
                 <path d="M45,9.7c-1.9,0-30.1,0-32,0s-3,1.2-3,3s0,40,0,40c0,0.6,0.2,1.2,0.5,1.7c0.5,0.8,1.4,1.3,2.5,1.3h32
 		c1.7,0,3-1.3,3-3c0,0,0-38.3,0-40S46.9,9.7,45,9.7z M43.4,51.1H14.6V14.4h28.7V51.1z"></path>


### PR DESCRIPTION
- Update to use version [6.5.1 of State Template package](https://template.webstandards.ca.gov/template-updates.html)
- Fix attribute names in SiteHeader.js